### PR TITLE
Handling of NaN in Kalman reconstruction

### DIFF
--- a/src/RigidBody/KalmanReconsMarkers.cpp
+++ b/src/RigidBody/KalmanReconsMarkers.cpp
@@ -11,7 +11,7 @@
 #include "RigidBody/GeneralizedAcceleration.h"
 #include "RigidBody/NodeSegment.h"
 
-#include <math.h> // isnan
+#include <math.h>
 
 biorbd::rigidbody::KalmanReconsMarkers::KalmanReconsMarkers() :
     biorbd::rigidbody::KalmanRecons(),

--- a/src/RigidBody/KalmanReconsMarkers.cpp
+++ b/src/RigidBody/KalmanReconsMarkers.cpp
@@ -11,6 +11,8 @@
 #include "RigidBody/GeneralizedAcceleration.h"
 #include "RigidBody/NodeSegment.h"
 
+#include <math.h> // isnan
+
 biorbd::rigidbody::KalmanReconsMarkers::KalmanReconsMarkers() :
     biorbd::rigidbody::KalmanRecons(),
     m_PpInitial(std::make_shared<biorbd::utils::Matrix>()),
@@ -149,7 +151,8 @@ void biorbd::rigidbody::KalmanReconsMarkers::reconstructFrame(
         // If there is a marker
         if (!Tobs(i*3).is_zero() && !Tobs(i*3+1).is_zero() && !Tobs(i*3+2).is_zero()){
 #else
-        if (Tobs(i*3)*Tobs(i*3) + Tobs(i*3+1)*Tobs(i*3+1) + Tobs(i*3+2)*Tobs(i*3+2) != 0.0){
+        if (Tobs(i*3)*Tobs(i*3) + Tobs(i*3+1)*Tobs(i*3+1) + Tobs(i*3+2)*Tobs(i*3+2) != 0.0 &&
+			!isnan(Tobs(i*3)*Tobs(i*3) + Tobs(i*3+1)*Tobs(i*3+1) + Tobs(i*3+2)*Tobs(i*3+2))){
 #endif
             H.block(i*3,0,3,*m_nbDof) = J_tp[i];
             zest.block(i*3, 0, 3, 1) = zest_tp[i];


### PR DESCRIPTION
Added handling of NaN in KalmanReconsMarkers.cpp, so they don't need to be converted to 0 before hand.