### PR TITLE
Wrapping objects naming issue

### DIFF
--- a/binding/python3/biorbd_python.i.in
+++ b/binding/python3/biorbd_python.i.in
@@ -26,12 +26,14 @@
 
 %include "@CMAKE_BINARY_DIR@/include/biorbdConfig.h"
 
+
 #if defined(BIORBD_USE_CASADI_MATH)
 #define SWIG_UTILS_STRING SWIGTYPE_p_BiorbdCasadi__utils__String
 #define SWIG_UTILS_PATH SWIGTYPE_p_BiorbdCasadi__utils__Path
 #define SWIG_UTILS_MATRIX3D SWIGTYPE_p_BiorbdCasadi__utils__Matrix3d
 #define SWIG_UTILS_VECTOR SWIGTYPE_p_BiorbdCasadi__utils__Vector
 #define SWIG_UTILS_NODE SWIGTYPE_p_BiorbdCasadi__utils__Node
+#define SWIG_UTILS_VECTOR3D SWIGTYPE_p_BiorbdCasadi__utils__Vector3d
 #define SWIG_UTILS_SPATIAL_VECTOR SWIGTYPE_p_BiorbdCasadi__utils__SpatialVector
 
 #define SWIG_RIGIDBODY_JOINTS SWIGTYPE_p_BiorbdCasadi__rigidbody__Joints
@@ -47,6 +49,7 @@
 #define SWIG_UTILS_MATRIX3D SWIGTYPE_p_BiorbdEigen3__utils__Matrix3d
 #define SWIG_UTILS_VECTOR SWIGTYPE_p_BiorbdEigen3__utils__Vector
 #define SWIG_UTILS_NODE SWIGTYPE_p_BiorbdEigen3__utils__Node
+#define SWIG_UTILS_VECTOR3D SWIGTYPE_p_BiorbdEigen3__utils__Vector3d
 #define SWIG_UTILS_SPATIAL_VECTOR SWIGTYPE_p_BiorbdEigen3__utils__SpatialVector
 
 #define SWIG_RIGIDBODY_JOINTS SWIGTYPE_p_BiorbdEigen3__rigidbody__Joints
@@ -933,7 +936,9 @@ BIORBD_NAMESPACE::rigidbody::GeneralizedAcceleration * {
 %typemap(typecheck, precedence=2130)
 BIORBD_NAMESPACE::utils::Vector3d &{
     void *argp1 = 0;
-    if (SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_NODE,  0  | 0)) && argp1) {
+    if (SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_NODE,  0  | 0))
+            || SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_VECTOR3D,  0  | 0))
+            && argp1) {
         // Test if it is a pointer to SWIG_UTILS_NODE already exists
         $1 = true;
      }
@@ -954,7 +959,9 @@ BIORBD_NAMESPACE::utils::Vector3d &{
 }
 %typemap(in) BIORBD_NAMESPACE::utils::Vector3d &{
     void * argp1 = 0;
-    if (SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_NODE,  0  | 0)) && argp1) {
+    if (SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_NODE,  0  | 0))
+            || SWIG_IsOK(SWIG_ConvertPtr($input, &argp1, SWIG_UTILS_VECTOR3D,  0  | 0))
+            && argp1) {
         // Recast the pointer
         $1 = reinterpret_cast< BIORBD_NAMESPACE::utils::Vector3d * >(argp1);
      }

--- a/examples/Test_longueur_wrapping.py
+++ b/examples/Test_longueur_wrapping.py
@@ -35,9 +35,8 @@ def roll(R, zi, zf, RT):
 
 # model
 model = biorbd.Model("WrappingObjectExample.bioMod")
-
 # wrapping RT matrix
-RTw = biorbd.WrappingCylinder(model.muscle(0).pathModifier().object(0)).RT(
+RTw = biorbd.WrappingHalfCylinder(model.muscle(0).pathModifier().object(0)).RT(
     model, np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 )
 RTw_trans = RTw.transpose()
@@ -66,7 +65,7 @@ for xb, yb, zb in zip(Xb, Yb, Zb):
 plt.show()
 
 # Compute muscle length
-r = biorbd.WrappingCylinder(model.muscle(0).pathModifier().object(0)).radius()
+r = biorbd.WrappingHalfCylinder(model.muscle(0).pathModifier().object(0)).radius()
 l_muscle_bd = model.muscle(0).musculoTendonLength(model, np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]))
 
 

--- a/examples/WrappingObjectExample.bioMod
+++ b/examples/WrappingObjectExample.bioMod
@@ -58,11 +58,11 @@ endmusclegroup
 
 		wrapping cyl1
 			parent Seg0
-			type cylinder
+			type halfcylinder
            		RT pi/10 pi/8 pi/6 xyz 0.1 0.2 0.3
 			muscle line
 			musclegroup Seg02seg1
-			diameter 0.1
+			radius 0.1
 			length 2
 			wrappingside 1
 		endwrapping

--- a/src/ModelReader.cpp
+++ b/src/ModelReader.cpp
@@ -1029,7 +1029,7 @@ void Reader::readModelFile(
                         static_cast<unsigned int>(iMuscle)).addPathObject(
                             cylinder);
                 } else {
-                    utils::Error::raise("Wrapping type must be defined (choices: 'cylinder')");
+                    utils::Error::raise("Wrapping type must be defined (choices: 'halfcylinder')");
                 }
 #else // MODULE_MUSCLES
                 utils::Error::raise("Biorbd was build without the module Muscles but the model defines a wrapping object");


### PR DESCRIPTION
A short PR concerning the naming issues due to changes in the `WrappingCylinder` class.
The example model and the python code are updated.
But the cpp examples should be updated too probably.

But I still have some issues with it, as far as I could understand it is due to the swig mapping.
I'll post the issue separately.
 
 