### PR TITLE
Muslce wrapping fix for cases when it is not needed

### DIFF
--- a/src/Muscles/WrappingHalfCylinder.cpp
+++ b/src/Muscles/WrappingHalfCylinder.cpp
@@ -122,9 +122,20 @@ void muscles::WrappingHalfCylinder::wrapPoints(
     findTangentToCircle(*p_glob.m_p1, p1_tan);
     findTangentToCircle(*p_glob.m_p2, p2_tan);
 
+
     // Find the vertical component
     NodeMusclePair tanPoints(p1_tan, p2_tan);
-    findVerticalNode(p_glob, tanPoints);
+
+    // if the wrap is not supposed to happen 
+    // if there is a straight line in between two points not passing throught the cylinder
+    if(!findVerticalNode(p_glob, tanPoints)){ 
+        // add the two wrapping points on that streight line
+        // each one at one third of length
+        Vector3d vec((*p_glob.m_p2 - *p_glob.m_p1)/3);
+        p1_tan = *p_glob.m_p1 + vec;
+        p2_tan = p1_tan + vec;
+        tanPoints = NodeMusclePair(p1_tan, p2_tan);
+    }
 
     // If asked, compute the distance distance traveled on the periphery of the cylinder
     // Apply pythagorus to the cercle arc
@@ -341,7 +352,7 @@ bool muscles::WrappingHalfCylinder::checkIfWraps(
     // if both points are on the left and we have to go left
     if ((*pointsInGlobal.m_p1)(0) > radius()
             && (*pointsInGlobal.m_p2)(0) > radius()) {
-        isWrap = false;
+        isWrap *= false;
     }
 
     // If we are on top of the wrap, it is impossible to determine because the wrap Si on est en haut du wrap*,
@@ -350,14 +361,14 @@ bool muscles::WrappingHalfCylinder::checkIfWraps(
     if ( ( (*pointsInGlobal.m_p1)(1) > 0 && (*pointsInGlobal.m_p2)(1) > 0)
             || ( (*pointsInGlobal.m_p1)(1) < 0
                  && (*pointsInGlobal.m_p2)(1) < 0) ) {
-        isWrap = false;
+        isWrap *= false;
     }
 
     // If we have a height* smaller than the radius, there is a numerical aberation
     // * en haut lorsque vue de dessus avec l'axe y pointant vers le haut...
     if ( fabs( (*pointsInGlobal.m_p1)(1)) < radius()
             || fabs( (*pointsInGlobal.m_p2)(1)) < radius() ) {
-        isWrap = false;
+        isWrap *= false;
     }
 
     // If we have reached this stage, one test is left
@@ -366,9 +377,9 @@ bool muscles::WrappingHalfCylinder::checkIfWraps(
               && (*pointsInGlobal.m_p1)(0) > (*pointsInGlobal.m_p2)(0)) ||
             ( (*pointsToWrap.m_p1)(0) > (*pointsToWrap.m_p2)(0)
               && (*pointsInGlobal.m_p1)(0) < (*pointsInGlobal.m_p2)(0))   ) {
-        isWrap = false;
+        isWrap *= false;
     } else {
-        isWrap = true;
+        isWrap *= true;
     }
 
     // Return the answer


### PR DESCRIPTION
Hello again, 
I've stumbled across an issue when using the wrapping. 
<img height="200" src="https://user-images.githubusercontent.com/36178713/128524026-d9b289b0-7421-4244-a2ea-2be75a913c78.png">   <img height="200" src="https://user-images.githubusercontent.com/36178713/128523788-6dab38eb-cefb-4b93-be58-faf83a8f448b.png">   <img height="200" src="https://user-images.githubusercontent.com/36178713/128523822-6256ed50-cb02-44a4-9ae7-65a2eb3097db.png">

The issue seems to be twofold: 
1. The function `findVerticalNode` returns `False` if the wrapping should not happen and puts both wrapping via-points to `Nan`. So muscle disappears because of `Nans` in calculations. (third image)
2. The calculation of the condition if he wrapping should happen `checkIfWraps` or not does not work 100% so we get the wrapping even though the straight line in between start and end of the muscle does not pass through the cylinder.  (second image)

So this PR is a proposition of a solution.
I've added a simple code to handle the non wrapping case, instead of sending `Nans` further. The via-points points are added on the straight line in between the muscle start and end point, each one on one third of the way. I am not sure if this is the best way yo handle this case though, but it seems to work well for my example.

Also, the I've slightly changed the condition handling in the `checkIfWraps` function and now it seems to be working well.

<img height="200" src="https://user-images.githubusercontent.com/36178713/128524176-6e981e6a-e711-45e6-93a1-ad69e007746f.png"><img height="200" src="https://user-images.githubusercontent.com/36178713/128524208-e6b97a71-2e22-407c-af04-dace85b0fae3.png"><img height="200" src="https://user-images.githubusercontent.com/36178713/128524234-1569dd1d-1a58-424e-a921-4bf7a868efd2.png">

All the changes are really slight and it seems to be working, at least for my examples. I'd be interested to hear what do you think. :smiley:  