### PR TITLE
GetBodyRbdlId added as a function for Python users.

### DIFF
--- a/include/RigidBody/Joints.h
+++ b/include/RigidBody/Joints.h
@@ -148,6 +148,14 @@ public:
         const utils::String &segmentName) const;
 
     ///
+    /// \brief Return the rbdl body identification
+    /// \param segmentName The name of the segment
+    /// \return The rbdl body identification
+    ///
+    int GetBodyRbdlId(
+        const utils::String &segmentName) const;
+
+    ///
     /// \brief Return the number of generalized torque
     /// \return The number of generalized torque
     ///

--- a/src/RigidBody/Joints.cpp
+++ b/src/RigidBody/Joints.cpp
@@ -338,14 +338,21 @@ std::vector<RigidBodyDynamics::Math::SpatialVector> * rigidbody::Joints::combine
     return f_ext_rbdl;
 }
 
-int rigidbody::Joints::GetBodyBiorbdId(const utils::String
-        &segmentName) const
+int rigidbody::Joints::GetBodyBiorbdId(
+        const utils::String &segmentName) const
 {
     for (int i=0; i<static_cast<int>(m_segments->size()); ++i)
         if (!(*m_segments)[static_cast<unsigned int>(i)].name().compare(segmentName)) {
             return i;
         }
     return -1;
+}
+
+
+int rigidbody::Joints::GetBodyRbdlId(
+        const utils::String &segmentName) const
+{
+    return GetBodyId(segmentName.c_str());
 }
 
 std::vector<utils::RotoTrans> rigidbody::Joints::allGlobalJCS(


### PR DESCRIPTION
GetBodyRbdlId added as a function for Python users, it allows to compute RBDL id of solid to set objects in model like markers, contacts from python.