### PR TITLE
Added mesh properties in ModelWriter (meshcolor, meshscale, meshrt)

### DIFF
--- a/include/RigidBody/Mesh.h
+++ b/include/RigidBody/Mesh.h
@@ -100,6 +100,12 @@ public:
             const utils::RotoTrans& rt);
 
     ///
+    /// \brief Get the rotation applied to the vertex
+    /// \return The Transformation applied to the mesh wrt the parent
+    ///
+    utils::RotoTrans& getRotation() const;
+
+    ///
     /// \brief Scale the vertex wrt to 0, 0, 0. Warnign, this function is
     /// applied when called, meaning that if it is called after rotate, it will
     /// results in surprising results!
@@ -107,6 +113,12 @@ public:
     ///
     void scale(
             const utils::Vector3d& scaler);
+
+    ///
+    /// \brief Get the scaling applied to the vertex wrt to 0, 0, 0.
+    /// \return The scaling applied to the mesh wrt the parent
+    ///
+    utils::Vector3d& getScale() const;
 
     ///
     /// \brief Add a face patch to the mesh
@@ -160,6 +172,8 @@ protected:
             m_faces; ///< The faces
     std::shared_ptr<utils::Path> m_pathFile; ///< The path to the mesh file
     std::shared_ptr<utils::Vector3d> m_patchColor; ///< The color of faces
+    std::shared_ptr<utils::RotoTrans> m_rotation; ///< The rotation
+    std::shared_ptr<utils::Vector3d> m_scale; ///< The scale
 };
 
 }

--- a/src/ModelWriter.cpp
+++ b/src/ModelWriter.cpp
@@ -8,6 +8,7 @@
 #include "Utils/String.h"
 #include "Utils/Path.h"
 #include "Utils/Matrix3d.h"
+#include "Utils/Vector.h"
 #include "RigidBody/IMU.h"
 #include "RigidBody/NodeSegment.h"
 #include "RigidBody/Segment.h"
@@ -77,6 +78,19 @@ void Writer::writeModel(Model & model,
             biorbdModelFile << sep << sep << "meshfile" << sep << model.segment(
                                 i).characteristics().mesh().path().originalPath() <<
                             std::endl;
+            biorbdModelFile << sep << sep << "meshcolor" << sep << model.segment(
+                i).characteristics().mesh().color().transpose() <<
+            std::endl;
+            biorbdModelFile << sep << sep << "meshscale" << sep << model.segment(
+                i).characteristics().mesh().getScale().transpose() <<
+            std::endl;
+
+            biorbdModelFile << sep << sep << "meshrt" << sep << 
+            utils::RotoTrans::toEulerAngles(model.segment(i).characteristics().mesh().getRotation(), 
+            utils::String("xyz")).transpose() <<
+            " xyz " <<
+            model.segment(i).characteristics().mesh().getRotation().trans().transpose() <<
+            std::endl;
         }
         biorbdModelFile << sep << "endsegment" << sep << std::endl;
         biorbdModelFile << std::endl;

--- a/src/RigidBody/Mesh.cpp
+++ b/src/RigidBody/Mesh.cpp
@@ -12,7 +12,9 @@ rigidbody::Mesh::Mesh() :
     m_vertex(std::make_shared<std::vector<utils::Vector3d>>()),
     m_faces(std::make_shared<std::vector<rigidbody::MeshFace>>()),
     m_pathFile(std::make_shared<utils::Path>()),
-    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788))
+    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788)),
+    m_rotation(std::make_shared<utils::RotoTrans>(RigidBodyDynamics::Math::Matrix4d::Identity())),
+    m_scale(std::make_shared<utils::Vector3d>(1.0, 1.0, 1.0))
 {
 
 }
@@ -22,7 +24,9 @@ rigidbody::Mesh::Mesh(
     m_vertex(std::make_shared<std::vector<utils::Vector3d>>(other)),
     m_faces(std::make_shared<std::vector<rigidbody::MeshFace>>()),
     m_pathFile(std::make_shared<utils::Path>()),
-    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788))
+    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788)),
+    m_rotation(std::make_shared<utils::RotoTrans>(RigidBodyDynamics::Math::Matrix4d::Identity())),
+    m_scale(std::make_shared<utils::Vector3d>(1.0, 1.0, 1.0))
 {
 
 }
@@ -33,7 +37,9 @@ rigidbody::Mesh::Mesh(const std::vector<utils::Vector3d>
     m_vertex(std::make_shared<std::vector<utils::Vector3d>>(vertex)),
     m_faces(std::make_shared<std::vector<rigidbody::MeshFace>>(faces)),
     m_pathFile(std::make_shared<utils::Path>()),
-    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788))
+    m_patchColor(std::make_shared<utils::Vector3d>(0.89, 0.855, 0.788)),
+    m_rotation(std::make_shared<utils::RotoTrans>(RigidBodyDynamics::Math::Matrix4d::Identity())),
+    m_scale(std::make_shared<utils::Vector3d>(1.0, 1.0, 1.0))
 {
 
 }
@@ -85,20 +91,32 @@ unsigned int rigidbody::Mesh::nbVertex() const
 
 void rigidbody::Mesh::rotate(
         const utils::RotoTrans &rt)
-{
+{   
+    *m_rotation = rt;
     for (auto& v : *m_vertex){
         v.applyRT(rt);
     }
 }
 
+utils::RotoTrans &rigidbody::Mesh::getRotation() const
+{
+    return *m_rotation;
+}
+
 void rigidbody::Mesh::scale(
         const utils::Vector3d &scaler)
-{
+{   
+    *m_scale = scaler;
     for (auto& v: *m_vertex){
         v(0) *= scaler(0);
         v(1) *= scaler(1);
         v(2) *= scaler(2);
     }
+}
+
+utils::Vector3d &rigidbody::Mesh::getScale() const
+{   
+    return *m_scale;
 }
 
 unsigned int rigidbody::Mesh::nbFaces()


### PR DESCRIPTION
This PR pertains to #253. I've added the `meshcolor`, `meshscale` and `meshrt` properties to the ModelWriter class. Compiled with Debug, Eigen3, Casadi and ran tests, all seems good. Ran the script [here](https://github.com/pyomeca/biorbd/issues/253#issue-1107468061) and the output .bioMod is correct now. 

I made two member variables in `Mesh` (`m_scale`, `m_rotation`), that keep track of the applied rotation and scale since that wasn't there before. Let me know if you'd like me to change anything!