### PR TITLE
[RTM if OK] remove error message in rootDynamics

### DIFF
--- a/src/RigidBody/Joints.cpp
+++ b/src/RigidBody/Joints.cpp
@@ -1489,8 +1489,8 @@ rigidbody::Joints::ForwardDynamicsFreeFloatingBase(
     const rigidbody::GeneralizedAcceleration& QJointsDDot)
 {
 
-    utils::Error::check(QJointsDDot.size() == this->nbQddot() - this->nbRoot(),
-                        "Size of QDDotJ must be equal to number of QDDot - number of root coordinates.");
+    // utils::Error::check(QJointsDDot.size() == this->nbQddot() - this->nbRoot(),
+    //                    "Size of QDDotJ must be equal to number of QDDot - number of root coordinates.");
     
     utils::Error::check(this->nbRoot() > 0, "Must have a least one degree of freedom on root.");
 


### PR DESCRIPTION
This error message is not necessary. It causes issues when the inputs are already of type GeneralizedCoordinates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/biorbd/324)
<!-- Reviewable:end -->
