### PR TITLE
Expose RBDL zero moment point

### DIFF
--- a/.github/workflows/publish_eigen_to_pypi.yml
+++ b/.github/workflows/publish_eigen_to_pypi.yml
@@ -41,7 +41,7 @@ jobs:
         
       - name: Install build packages
         run: | 
-          conda install pip "swig<4.4.0" eigen -cconda-forge
+          conda install pip "swig<4.4.0" "eigen<4.0.0" -c conda-forge
           conda list
           pip install build cibuildwheel==2.21.3
 

--- a/.github/workflows/run_casadi_tests.yml
+++ b/.github/workflows/run_casadi_tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         include:
           - os: ubuntu-latest
             label: linux-64
@@ -18,7 +18,7 @@ jobs:
           - os: macos-latest
             label: osx-arm64
             prefix: /Users/runner/miniconda3/envs/biorbd
-          - os: windows-latest
+          - os: windows-2022
             label: win-64
             prefix: C:\Miniconda3\envs\biorbd
     name: ${{ matrix.label }}

--- a/.github/workflows/run_eigen_tests.yml
+++ b/.github/workflows/run_eigen_tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         include:
           - os: ubuntu-latest
             label: linux-64
@@ -20,7 +20,7 @@ jobs:
             label: osx-arm64
             prefix: /Users/runner/miniconda3/envs/biorbd
             use_matlab: ON
-          - os: windows-latest
+          - os: windows-2022
             label: win-64
             prefix: C:\Miniconda3\envs\biorbd
             use_matlab: ON

--- a/.github/workflows/run_pip_tests.yml
+++ b/.github/workflows/run_pip_tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
         include:
           - os: ubuntu-latest
             label: linux-64
@@ -18,7 +18,7 @@ jobs:
           # - os: macos-latest
           #   label: osx-arm64
           #   prefix: /Users/runner/miniconda3/envs/biorbd
-          - os: windows-latest
+          - os: windows-2022
             label: win-64
             prefix: C:\Miniconda3\envs\biorbd
     name: ${{ matrix.label }}

--- a/.github/workflows/run_pip_tests.yml
+++ b/.github/workflows/run_pip_tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -cconda-forge "swig<4.4.0" pip eigen
+          conda install -cconda-forge "swig<4.4.0" pip "eigen<4.0.0"
           conda list
 
       - name: Setup Linux dependencies

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The building status for the current BIORBD branches is as follow
 | DOI | [![DOI](https://zenodo.org/badge/124423173.svg)](https://zenodo.org/badge/latestdoi/124423173) |
 
 ### Dependencies
-BIORBD relies on several libraries (namely eigen ([http://eigen.tuxfamily.org]) or CasADi ([https://web.casadi.org/]), rbdl-casadi (https://github.com/pyomeca/rbdl-casadi), tinyxml2(https://github.com/leethomason/tinyxml2) and Ipopt (https://github.com/coin-or/Ipopt)) that one must install prior to compiling. Fortunately, all these dependencies are also hosted on the *conda-forge* channel of Anaconda or will automatically be compiled when building BIORBD. Therefore the following command will install everything you need to compile BIORBD:
+BIORBD relies on several libraries (namely eigen ([http://eigen.tuxfamily.org] up to version 3.4.0) or CasADi ([https://web.casadi.org/]), rbdl-casadi (https://github.com/pyomeca/rbdl-casadi), tinyxml2(https://github.com/leethomason/tinyxml2) and Ipopt (https://github.com/coin-or/Ipopt)) that one must install prior to compiling. Fortunately, all these dependencies are also hosted on the *conda-forge* channel of Anaconda or will automatically be compiled when building BIORBD. Therefore the following command will install everything you need to compile BIORBD:
 ```bash
 conda install -c conda-forge rbdl [ipopt] [pkgconfig] [cmake] [scipy]
 ```

--- a/binding/python3/wrapper/biorbd_model.py
+++ b/binding/python3/wrapper/biorbd_model.py
@@ -146,6 +146,44 @@ class Biorbd:
         update_kinematics = False
         return to_biorbd_array_output(updated_model.CoM(dummy_q, update_kinematics))
 
+    def zero_moment_point(
+        self,
+        q: BiorbdArray,
+        qdot: BiorbdArray,
+        qddot: BiorbdArray,
+        normal: BiorbdArray = (0, 0, 1),
+        point: BiorbdArray = (0, 0, 0),
+    ) -> BiorbdArray:
+        """
+        Get the zero moment point projected on a contact surface.
+
+        Parameters
+        ----------
+        q: BiorbdArray
+            Generalized coordinates
+        qdot: BiorbdArray
+            Generalized velocities
+        qddot: BiorbdArray
+            Generalized accelerations
+        normal: BiorbdArray
+            Normal of the contact surface
+        point: BiorbdArray
+            A point on the contact surface
+
+        Returns
+        -------
+        The zero moment point in the base frame
+        """
+        return to_biorbd_array_output(
+            self.internal.CalcZeroMomentPoint(
+                to_biorbd_array_input(q),
+                to_biorbd_array_input(qdot),
+                to_biorbd_array_input(qddot),
+                to_biorbd_array_input(normal),
+                to_biorbd_array_input(point),
+            )
+        )
+
     @property
     def segments(self) -> SegmentsList:
         """

--- a/environment_eigen.yml
+++ b/environment_eigen.yml
@@ -5,7 +5,7 @@ channels:
 - default
 dependencies:
 - python >=3.10
-- eigen
+- eigen <4.0.0
 - rbdl >=3.3.0
 - scipy
 - ezc3d

--- a/include/RigidBody/Joints.h
+++ b/include/RigidBody/Joints.h
@@ -717,6 +717,38 @@ class BIORBD_API Joints : public RigidBodyDynamics::Model
       bool updateKin = true);
 
   ///
+  /// \brief Compute the zero moment point on a contact surface.
+  /// \param Q The current joint positions
+  /// \param Qdot The current joint velocities
+  /// \param Qddot The current joint accelerations
+  /// \param updateKin If the kinematics of the model should be computed
+  /// \return The Zero Moment Point projected on the horizontal surface
+  ///
+  utils::Vector3d CalcZeroMomentPoint(
+      const rigidbody::GeneralizedCoordinates& Q,
+      const rigidbody::GeneralizedVelocity& Qdot,
+      const rigidbody::GeneralizedAcceleration& Qddot,
+      bool updateKin = true);
+
+  ///
+  /// \brief Compute the zero moment point on a contact surface.
+  /// \param Q The current joint positions
+  /// \param Qdot The current joint velocities
+  /// \param Qddot The current joint accelerations
+  /// \param normal The normal of the contact surface
+  /// \param point A point on the contact surface
+  /// \param updateKin If the kinematics of the model should be computed
+  /// \return The Zero Moment Point projected on the contact surface
+  ///
+  utils::Vector3d CalcZeroMomentPoint(
+      const rigidbody::GeneralizedCoordinates& Q,
+      const rigidbody::GeneralizedVelocity& Qdot,
+      const rigidbody::GeneralizedAcceleration& Qddot,
+      const utils::Vector3d& normal,
+      const utils::Vector3d& point,
+      bool updateKin = true);
+
+  ///
   /// \brief Return the position of the center of mass of each segment
   /// \param Q The generalized coordinates
   /// \param updateKin If the kinematics of the model should be computed

--- a/src/RigidBody/Joints.cpp
+++ b/src/RigidBody/Joints.cpp
@@ -1070,6 +1070,8 @@ utils::Vector3d rigidbody::Joints::CalcZeroMomentPoint(
   RigidBodyDynamics::Utils::CalcZeroMomentPoint(
       updatedModel, Q, Qdot, Qddot, &zmp, normal, point, false);
 
+  zmp += normal * ((point - zmp).dot(normal) / normal.dot(normal));
+
   return zmp;
 }
 

--- a/src/RigidBody/Joints.cpp
+++ b/src/RigidBody/Joints.cpp
@@ -1035,6 +1035,44 @@ void rigidbody::Joints::CalcCenterOfMass(
       false);
 }
 
+utils::Vector3d rigidbody::Joints::CalcZeroMomentPoint(
+    const rigidbody::GeneralizedCoordinates &Q,
+    const rigidbody::GeneralizedVelocity &Qdot,
+    const rigidbody::GeneralizedAcceleration &Qddot,
+    bool updateKin) {
+  return CalcZeroMomentPoint(
+      Q,
+      Qdot,
+      Qddot,
+      utils::Vector3d(0., 0., 1.),
+      utils::Vector3d(0., 0., 0.),
+      updateKin);
+}
+
+utils::Vector3d rigidbody::Joints::CalcZeroMomentPoint(
+    const rigidbody::GeneralizedCoordinates &Q,
+    const rigidbody::GeneralizedVelocity &Qdot,
+    const rigidbody::GeneralizedAcceleration &Qddot,
+    const utils::Vector3d &normal,
+    const utils::Vector3d &point,
+    bool updateKin) {
+#ifdef BIORBD_USE_CASADI_MATH
+  rigidbody::Joints
+#else
+  rigidbody::Joints &
+#endif
+      updatedModel = this->UpdateKinematicsCustom(
+          updateKin ? &Q : nullptr,
+          updateKin ? &Qdot : nullptr,
+          updateKin ? &Qddot : nullptr);
+
+  utils::Vector3d zmp;
+  RigidBodyDynamics::Utils::CalcZeroMomentPoint(
+      updatedModel, Q, Qdot, Qddot, &zmp, normal, point, false);
+
+  return zmp;
+}
+
 std::vector<rigidbody::NodeSegment> rigidbody::Joints::CoMbySegment(
     const rigidbody::GeneralizedCoordinates &Q,
     bool updateKin) {

--- a/test/binding/python3/test_binder_python_rigidbody.py
+++ b/test/binding/python3/test_binder_python_rigidbody.py
@@ -250,33 +250,48 @@ def test_zero_moment_point(brbd):
     q = np.array([0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3])
     q_dot = np.array([1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3])
     q_ddot = np.array([10, 10, 10, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
+    def compute_zero_moment_point(normal, point):
+        if brbd.backend == brbd.CASADI:
+            from casadi import MX
+
+            q_sym = MX.sym("q", m.nbQ(), 1)
+            q_dot_sym = MX.sym("q_dot", m.nbQdot(), 1)
+            q_ddot_sym = MX.sym("q_ddot", m.nbQddot(), 1)
+
+            zero_moment_point_func = brbd.to_casadi_func(
+                "Compute_Zero_Moment_Point",
+                m.CalcZeroMomentPoint,
+                q_sym,
+                q_dot_sym,
+                q_ddot_sym,
+                normal,
+                point,
+            )
+            zero_moment_point = np.array(zero_moment_point_func(q, q_dot, q_ddot))
+
+        elif brbd.backend == brbd.EIGEN3:
+            zero_moment_point = m.CalcZeroMomentPoint(q, q_dot, q_ddot, normal, point).to_array()
+        else:
+            raise NotImplementedError("Backend not implemented in test")
+
+        return zero_moment_point.squeeze()
+
     normal = np.array([0, 0, 1])
-    point = np.array([0, 0, 0.1])
+    origin_point = np.array([0, 0, 0])
+    shifted_point = np.array([0, 0, 0.1])
+    zero_moment_point = compute_zero_moment_point(normal, shifted_point)
 
-    if brbd.backend == brbd.CASADI:
-        from casadi import MX
+    np.testing.assert_almost_equal(np.dot(zero_moment_point - shifted_point, normal), 0)
 
-        q_sym = MX.sym("q", m.nbQ(), 1)
-        q_dot_sym = MX.sym("q_dot", m.nbQdot(), 1)
-        q_ddot_sym = MX.sym("q_ddot", m.nbQddot(), 1)
+    origin_zero_moment_point = compute_zero_moment_point(normal, origin_point)
+    np.testing.assert_almost_equal(zero_moment_point[:2], origin_zero_moment_point[:2])
 
-        zero_moment_point_func = brbd.to_casadi_func(
-            "Compute_Zero_Moment_Point",
-            m.CalcZeroMomentPoint,
-            q_sym,
-            q_dot_sym,
-            q_ddot_sym,
-            normal,
-            point,
-        )
-        zero_moment_point = np.array(zero_moment_point_func(q, q_dot, q_ddot))
-
-    elif brbd.backend == brbd.EIGEN3:
-        zero_moment_point = m.CalcZeroMomentPoint(q, q_dot, q_ddot, normal, point).to_array()
-    else:
-        raise NotImplementedError("Backend not implemented in test")
-
-    np.testing.assert_almost_equal(zero_moment_point.squeeze()[2], point[2])
+    sagittal_normal = np.array([0, 1, 0])
+    sagittal_point = np.array([0, 0.2, 0])
+    sagittal_zero_moment_point = compute_zero_moment_point(sagittal_normal, sagittal_point)
+    np.testing.assert_almost_equal(
+        np.dot(sagittal_zero_moment_point - sagittal_point, sagittal_normal), 0
+    )
 
 
 @pytest.mark.parametrize("brbd", brbd_to_test)

--- a/test/binding/python3/test_binder_python_rigidbody.py
+++ b/test/binding/python3/test_binder_python_rigidbody.py
@@ -244,6 +244,42 @@ def test_com(brbd):
 
 
 @pytest.mark.parametrize("brbd", brbd_to_test)
+def test_zero_moment_point(brbd):
+    m = brbd.Model("../../models/pyomecaman.bioMod")
+
+    q = np.array([0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3])
+    q_dot = np.array([1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3])
+    q_ddot = np.array([10, 10, 10, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30])
+    normal = np.array([0, 0, 1])
+    point = np.array([0, 0, 0.1])
+
+    if brbd.backend == brbd.CASADI:
+        from casadi import MX
+
+        q_sym = MX.sym("q", m.nbQ(), 1)
+        q_dot_sym = MX.sym("q_dot", m.nbQdot(), 1)
+        q_ddot_sym = MX.sym("q_ddot", m.nbQddot(), 1)
+
+        zero_moment_point_func = brbd.to_casadi_func(
+            "Compute_Zero_Moment_Point",
+            m.CalcZeroMomentPoint,
+            q_sym,
+            q_dot_sym,
+            q_ddot_sym,
+            normal,
+            point,
+        )
+        zero_moment_point = np.array(zero_moment_point_func(q, q_dot, q_ddot))
+
+    elif brbd.backend == brbd.EIGEN3:
+        zero_moment_point = m.CalcZeroMomentPoint(q, q_dot, q_ddot, normal, point).to_array()
+    else:
+        raise NotImplementedError("Backend not implemented in test")
+
+    np.testing.assert_almost_equal(zero_moment_point.squeeze()[2], point[2])
+
+
+@pytest.mark.parametrize("brbd", brbd_to_test)
 def test_set_vector3d(brbd):
     m = brbd.Model("../../models/pyomecaman.bioMod")
     m.setGravity(np.array((0, 0, -2)))

--- a/test/binding/python3/tests_wrapper/test_wrapper_dynamics.py
+++ b/test/binding/python3/tests_wrapper/test_wrapper_dynamics.py
@@ -56,18 +56,18 @@ def test_wrapper_dynamics(brbd):
         ],
         decimal=6,
     )
-    np.testing.assert_almost_equal(
-        evaluate(
-            brbd,
-            model.zero_moment_point,
-            q=q,
-            qdot=qdot,
-            qddot=qddot,
-            normal=np.array([0, 0, 1]),
-            point=np.array([0, 0, 0.1]),
-        )[2],
-        0.1,
+    normal = np.array([0, 0, 1])
+    point = np.array([0, 0, 0.1])
+    zero_moment_point = evaluate(
+        brbd,
+        model.zero_moment_point,
+        q=q,
+        qdot=qdot,
+        qddot=qddot,
+        normal=normal,
+        point=point,
     )
+    np.testing.assert_almost_equal(np.dot(zero_moment_point - point, normal), 0)
 
 
 if __name__ == "__main__":

--- a/test/binding/python3/tests_wrapper/test_wrapper_dynamics.py
+++ b/test/binding/python3/tests_wrapper/test_wrapper_dynamics.py
@@ -56,6 +56,18 @@ def test_wrapper_dynamics(brbd):
         ],
         decimal=6,
     )
+    np.testing.assert_almost_equal(
+        evaluate(
+            brbd,
+            model.zero_moment_point,
+            q=q,
+            qdot=qdot,
+            qddot=qddot,
+            normal=np.array([0, 0, 1]),
+            point=np.array([0, 0, 0.1]),
+        )[2],
+        0.1,
+    )
 
 
 if __name__ == "__main__":

--- a/test/test_rigidbody.cpp
+++ b/test/test_rigidbody.cpp
@@ -6,6 +6,7 @@
 
 #include <rbdl/Dynamics.h>
 #include <rbdl/rbdl_math.h>
+#include <rbdl/rbdl_utils.h>
 
 #include "BiorbdModel.h"
 #include "RigidBody/ExternalForceSet.h"
@@ -1463,6 +1464,34 @@ TEST(CoM, kinematics) {
     EXPECT_NEAR(
         static_cast<double>(comDdot(i, 0)),
         expectedComDdot[i],
+        requiredPrecision);
+  }
+}
+
+TEST(CoM, zeroMomentPoint) {
+  Model model(modelPathForGeneralTesting);
+  Model expectedModel(modelPathForGeneralTesting);
+  rigidbody::GeneralizedCoordinates Q(model);
+  rigidbody::GeneralizedVelocity Qdot(model);
+  rigidbody::GeneralizedAcceleration Qddot(model);
+  for (size_t i = 0; i < model.nbQ(); ++i) {
+    Q(i, 0) = QtestPyomecaman[i];
+    Qdot(i, 0) = QtestPyomecaman[i] * 10;
+    Qddot(i, 0) = QtestPyomecaman[i] * 100;
+  }
+
+  utils::Vector3d normal(0, 0, 1);
+  utils::Vector3d point(0, 0, 0);
+  utils::Vector3d zeroMomentPoint(
+      model.CalcZeroMomentPoint(Q, Qdot, Qddot, normal, point));
+  utils::Vector3d expectedZeroMomentPoint;
+  RigidBodyDynamics::Utils::CalcZeroMomentPoint(
+      expectedModel, Q, Qdot, Qddot, &expectedZeroMomentPoint, normal, point);
+
+  for (size_t i = 0; i < 3; ++i) {
+    EXPECT_NEAR(
+        static_cast<double>(zeroMomentPoint(i, 0)),
+        static_cast<double>(expectedZeroMomentPoint(i, 0)),
         requiredPrecision);
   }
 }

--- a/test/test_rigidbody.cpp
+++ b/test/test_rigidbody.cpp
@@ -1494,6 +1494,34 @@ TEST(CoM, zeroMomentPoint) {
         static_cast<double>(expectedZeroMomentPoint(i, 0)),
         requiredPrecision);
   }
+
+  utils::Vector3d shiftedPoint(0, 0, 0.1);
+  utils::Vector3d shiftedZeroMomentPoint(
+      model.CalcZeroMomentPoint(Q, Qdot, Qddot, normal, shiftedPoint));
+
+  EXPECT_NEAR(
+      static_cast<double>((shiftedZeroMomentPoint - shiftedPoint).dot(normal)),
+      0.,
+      requiredPrecision);
+  EXPECT_NEAR(
+      static_cast<double>(shiftedZeroMomentPoint(0, 0)),
+      static_cast<double>(zeroMomentPoint(0, 0)),
+      requiredPrecision);
+  EXPECT_NEAR(
+      static_cast<double>(shiftedZeroMomentPoint(1, 0)),
+      static_cast<double>(zeroMomentPoint(1, 0)),
+      requiredPrecision);
+
+  utils::Vector3d sagittalNormal(0, 1, 0);
+  utils::Vector3d sagittalPoint(0, 0.2, 0);
+  utils::Vector3d sagittalZeroMomentPoint(model.CalcZeroMomentPoint(
+      Q, Qdot, Qddot, sagittalNormal, sagittalPoint));
+
+  EXPECT_NEAR(
+      static_cast<double>(
+          (sagittalZeroMomentPoint - sagittalPoint).dot(sagittalNormal)),
+      0.,
+      requiredPrecision);
 }
 
 TEST(Segment, copy) {


### PR DESCRIPTION
## Summary
- expose RBDL CalcZeroMomentPoint through biorbd rigidbody::Joints
- add Python wrapper convenience method zero_moment_point
- add C++ and Python tests for the projected contact-surface ZMP

## Testing
- git diff --check
- python3 -c 'import ast, pathlib; [ast.parse(pathlib.Path(p).read_text()) for p in ["binding/python3/wrapper/biorbd_model.py", "test/binding/python3/test_binder_python_rigidbody.py", "test/binding/python3/tests_wrapper/test_wrapper_dynamics.py"]]; print("python syntax ok")'

Full C++/binding test suite was not run locally because this checkout has no configured build directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/biorbd/383)
<!-- Reviewable:end -->
